### PR TITLE
Port PR 1486 from the old repo

### DIFF
--- a/cspr-docs/config/sidebar.config.js
+++ b/cspr-docs/config/sidebar.config.js
@@ -38,7 +38,14 @@ module.exports = {
                 type: "doc",
                 id: "concepts/economics/index",
             },
-            items: ["concepts/economics/consensus", "concepts/economics/runtime", "concepts/economics/gas-concepts", "concepts/economics/staking"],
+            items: [
+                "concepts/economics/consensus",
+                "concepts/economics/runtime",
+                "concepts/economics/gas-concepts",
+                "concepts/economics/dynamic-gas-pricing",
+                "concepts/economics/fee-elimination",
+                "concepts/economics/staking",
+            ],
         },
         {
             type: "category",
@@ -87,11 +94,7 @@ module.exports = {
                 type: "doc",
                 id: "concepts/serialization/index",
             },
-            items: [
-                "concepts/serialization/primitives",
-                "concepts/serialization/structures",
-                "concepts/serialization/types",
-            ],
+            items: ["concepts/serialization/primitives", "concepts/serialization/structures", "concepts/serialization/types"],
         },
         "concepts/intro-to-dapps",
         "concepts/addressable-entity",

--- a/cspr-docs/docs/concepts/design/casper-design.md
+++ b/cspr-docs/docs/concepts/design/casper-design.md
@@ -36,9 +36,7 @@ Although the network measures costs in `Gas`, payment for computation occurs in 
 
 :::note
 
-Please note that Casper will not refund any amount of unused gas.
-
-This decision is taken to incentivize the [Casper Runtime Economics](../economics/runtime.md#runtime-economics) by efficiently allocating the computational resources. The [consensus-before-execution model](../economics/runtime.md#consensus-before-execution-basics-of-payment) implements the mechanism to encourage the optimized gas consumption from users and to prevent the overuse of block space by poorly handled transactions.
+Casper networks support configurable fee, refund, and pricing strategies to incentivize the [Casper Runtime Economics](../economics/runtime.md#runtime-economics) by efficiently allocating computational resources. The [consensus-before-execution model](../economics/runtime.md#consensus-before-execution-basics-of-payment) implements the mechanism to encourage optimized gas consumption from users and to prevent the overuse of block space by poorly handled transactions.
 
 :::
 

--- a/cspr-docs/docs/concepts/economics/dynamic-gas-pricing.md
+++ b/cspr-docs/docs/concepts/economics/dynamic-gas-pricing.md
@@ -1,0 +1,63 @@
+---
+title: Dynamic Gas Pricing
+---
+
+# Dynamic Gas Pricing on Mainnet
+
+The Condor release introduced a configurable capability to calculate dynamic gas prices based on block vacancy (or consumption). The network chainspec configures the `vacancy`, as shown below, which refers to this feature. This capability prevents malicious actors from filling the blocks with useless transactions and ensures network integrity.
+
+When dynamic gas pricing is enabled, a calculation runs at the end of each era to average block usage within that era. This calculation determines the gas price the network will use for the next era. If overall consumption rises above a threshold, the gas price increases by 1. If consumption falls below a threshold, the gas price decreases by 1. The gas price remains the same if overall consumption remains within those thresholds. The gas price will not go up or down by more than 1 in a given era and will not go above the maximum or below the minimum threshold.
+
+The gas price is recorded in the block header and is easily discoverable for current and historical purposes. The current gas price is a multiplier that determines the actual gas cost. For instance, an operation with a base cost of 1 CSPR would cost 1 CSPR if the current gas price is 1 but would cost 2 CSPR if the current gas price is 2. As blocks become congested, the amount of CSPR required to obtain a slot for executing transactions will increase by a multiple. The following configuration settings control this behavior:
+
+- `upper_threshold` - The threshold to decrease gas price
+- `lower_threshold` - The threshold to increase gas price
+- `max_gas_price` - The maximum gas price
+- `min_gas_price` - The minimum gas price
+
+
+### Mainnet Condor Configurations
+
+These are the block vacancy (dynamic gas pricing) settings for the Condor release on Mainnet. Before Condor, the gas price was 1, meaning 1 unit of gas cost 1 mote. With Condor, the multiple is configured to adjust between 1 and 3.
+
+<!--TODO check and update these settings after the launch or link to the chainspec file directly.-->
+
+```toml
+[vacancy]
+# The cost of a transaction is based on a multiplier. This allows for economic disincentives for misuse of the network.
+#
+# The network starts with a current_gas_price of min_gas_price.
+#
+# Each block has multiple limits (bytes, transactions, transfers, gas, etc.)
+# The utilization for a block is determined by the highest percentage utilization of each these limits.
+#
+# Ex: transfers limit is 650 and transactions limit is 20 (assume other limits are not a factor here)
+#     19 transactons -> 19/20 or 95%
+#     600 transfers -> 600/650 or 92.3%
+#     resulting block utilization is 95
+#
+# The utilization for an era is the average of all block utilizations. At the switch block, the dynamic gas_price is
+# adjusted with the following:
+#
+# If utilization was below the lower_threshold, current_gas_price is decremented by one if higher than min_gas_price.
+# If utilization falls between the thresholds, current_gas_price is not changed.
+# If utilization was above the upper_threshold, current_gas_price is incremented by one if lower than max_gas_price.
+#
+# The cost charged for the transaction is simply the gas_used * current_gas_price.
+upper_threshold = 90
+lower_threshold = 50
+max_gas_price = 3
+min_gas_price = 1
+```
+
+## Fixed Transaction Costs vs. Dynamic Gas Prices
+
+The current gas price and the slot’s maximum gas cost determine how much CSPR gets locked up for a transaction. Thus, the transaction price is predictable and fixed but has a dynamic component in that it’s pegged to the gas price. The system is designed this way to protect the network, adjusting the gas price as needed. Read more about lanes and gas cost [here](./runtime.md#lanes-and-gas-costs-lanes). Also, the `pricing_handling = { type = 'fixed' }` setting is described [here](./fee-elimination.md).
+
+## Gas Tolerance
+
+:::caution
+The cost of interacting with the blockchain increases during high network usage. Plan accordingly for any transactions and use the gas_tolerance field described below.
+:::
+
+Transactions have a `gas_tolerance` field, allowing the sender to specify the maximum gas price they are willing to pay (the minimum is 1). For instance, if a transaction is sent with `gas_tolerance = 2` and the network is currently at a gas price of 3 or higher, that transaction will not be included in a proposed block. If the calculated gas price decreases to 2 before the transaction has expired, the transaction will be eligible for inclusion in a proposed block.

--- a/cspr-docs/docs/concepts/economics/fee-elimination.md
+++ b/cspr-docs/docs/concepts/economics/fee-elimination.md
@@ -1,0 +1,93 @@
+---
+title: Fee Elimination
+---
+
+# Fee Elimination on Mainnet
+
+Casper networks support configurable fee, refund, and pricing strategies. The Mainnet Condor release has enabled "fee elimination", also known as the "no fee mode", or "no fee transactions" to reduce operational costs for developers. This configurable feature places balance holds on a user's purse rather than taking fees for sending transactions to the network. This behavior benefits parties who send periodic transactions, as their gas costs are locked for some time and then either released all at once or linearly over time, depending on the chainspec settings. Recall that the network chainspec contains all the configuration choices on which every node must agree.
+
+Instead of paying for gas to execute transactions, the `no_fee` chainspec configuration instructs the network to place a balance hold on the paying purse without transferring tokens from the purse: `fee_handling = { type = 'no_fee'}`. The portion of a purse balance that is locked is not available to transfer or spend until it is released; it is marked with a timestamp equal to the block time. In the "no fee" mode, the available balance of a purse equals its actual total balance minus all non-expired balance holds on that purse. The configurable `gas_hold_interval` determines how long a balance hold remains in effect. The on-chain logic calculates the correct values for total balance and available balance. The [query_balance_details](../../developers/json-rpc/json-rpc-informational.md#query_balance_details) RPC endpoint provides details on available balances and hold records.
+
+:::note
+
+A processing hold is not the same as a gas (or balance) hold. The processing hold is a temporary hold that prevents double spend. For example, if you want to do a transfer, you also need to cover the cost of the transfer.
+
+:::
+
+## Chainspec Configurations
+
+The following [chainspec configurations](../../operators/setup-network/chain-spec.md) manage this feature:
+
+-   `fee_handling` - Defines how fees are handled. To enable the "no fee" mode, set it to `{ type = 'no_fee'}`.
+-   `refund_handling` Defines how refunds of the unused portion of payment amounts are calculated and handled. For this setting to work with the "no fee" mode, set it to `{ type = 'no_refund'}`. If no fees are transferred from the paying purse, no refunds need to be paid out.
+-   `pricing_handling` - Defines how pricing is handled. For this setting to work with the `no_fee` mode, set it to `{ type = 'fixed'}`, which means that costs are fixed per the cost table, and senders do not specify how much they pay.
+-   `validator_credit_cap` - The validator credit cannot exceed this percentage of their total stake.
+- `gas_hold_balance_handling - Defines how gas holds affect available balance calculations. Valid options are 'accrued' (the sum of the full value of all non-expired holds) and 'amortized' (the sum of each hold is amortized over the time remaining until expiry).
+-   `gas_hold_interval` - Defines how long gas holds last.
+
+### Mainnet Condor Configurations
+
+These are the fee elimination settings for the Condor release on Mainnet:
+<!--TODO check and update these settings after the launch or link to the chainspec file directly.-->
+
+```toml
+# Defines how refunds of the unused portion of payment amounts are calculated and handled.
+#
+# Valid options are:
+#   'refund': a ratio of the unspent token is returned to the spender.
+#   'burn': a ratio of the unspent token is burned.
+#   'no_refund': no refunds are paid out; this is functionally equivalent to refund with 0% ratio.
+# This causes excess payment amounts to be sent to either a
+# pre-defined purse, or back to the sender.  The refunded amount is calculated as the given ratio of the payment amount
+# minus the execution costs.
+refund_handling = { type = 'no_refund' }
+# Defines how fees are handled.
+#
+# Valid options are:
+#   'no_fee': fees are eliminated.
+#   'pay_to_proposer': fees are paid to the block proposer
+#   'accumulate': fees are accumulated in a special purse and distributed at the end of each era evenly among all
+#                 administrator accounts
+#   'burn': fees are burned
+fee_handling = { type = 'no_fee' }
+# If a validator would recieve a validator credit, it cannot exceed this percentage of their total stake.
+validator_credit_cap = [1, 5]
+# Defines how pricing is handled.
+#
+# Valid options are:
+#   'classic': senders of transaction self-specify how much they pay.
+#   'fixed': costs are fixed, per the cost table
+#   'reserved': prepaid transaction (currently not supported)
+pricing_handling = { type = 'fixed' }
+
+# Defines how gas holds affect available balance calculations.
+#
+# Valid options are:
+#   'accrued': sum of full value of all non-expired holds.
+#   'amortized': sum of each hold is amortized over the time remaining until expiry.
+#
+# For instance, if 12 hours remained on a gas hold with a 24-hour `gas_hold_interval`,
+#   with accrued, the full hold amount would be applied
+#   with amortized, half the hold amount would be applied
+gas_hold_balance_handling = { type = 'accrued' }
+# Defines how long gas holds last.
+#
+# If fee_handling is set to 'no_fee', the system places a balance hold on the payer
+# equal to the value the fee would have been. Such balance holds expire after a time
+# interval has elapsed. This setting controls how long that interval is. The available
+# balance of a purse equals its total balance minus the held amount(s) of non-expired
+# holds (see gas_hold_balance_handling setting for details of how that is calculated).
+#
+# For instance, if gas_hold_interval is 24 hours and 100 gas is used from a purse,
+# a hold for 100 is placed on that purse and is considered when calculating total balance
+# for 24 hours starting from the block_time when the hold was placed.
+gas_hold_interval = '24 hours'
+```
+
+## Computational and Storage Costs
+
+Despite the introduction of fee elimination, the network continues to track [computational cost](../design/casper-design.md#measuring-computational-work-execution-semantics-gas) based on opcodes as defined in the chainspec, thus retaining the [gas pricing mechanism](./gas-concepts.md). Opcodes enable Casper nodes to agree on the computational cost of transactions, commonly known as gas. This mechanism is a solution to the halting problem in a distributed network, and it abstracts the computational cost in a way that is deterministically consistent across multiple machines.
+
+Storage costs are also tracked and calculated using gas. Data written to global state is recorded forever and has a cost; therefore, the network charges for the Wasm that stores data in global state.
+
+This feature complements the [dynamic gas pricing](./dynamic-gas-pricing.md) model introduced and configured to scale gas costs based on network utilization.

--- a/cspr-docs/docs/concepts/economics/gas-concepts.md
+++ b/cspr-docs/docs/concepts/economics/gas-concepts.md
@@ -8,50 +8,20 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 ## What is gas?
 
-Gas is a conceptual measure of resources used when executing transactions on the blockchain. Cost is the amount of gas consumed during the processing cycles that execute a transaction on the network. It is directly correlated with the amount of computer processing a validator needs to provide in order to execute a transaction.
+Gas is a conceptual measure of resources used while executing transactions on the blockchain. Gas cost is the amount of gas consumed during the processing cycles that execute a transaction on the network. It correlates directly with the amount of computer processing a validator needs to provide to execute a transaction.
 
-Gas fees are consumed on the network irrespective of whether your transaction was successful or not. Even when a transaction fails, you have to pay the transaction fee because your deploy consumed resources and space on the block as the validator attempted to execute it on your behalf.
+Gas fees are consumed on the network irrespective of whether a transaction was successful or not. Even when a transaction fails, the network measures [computational work as gas](../design/casper-design.md#measuring-computational-work-execution-semantics-gas) because it consumes resources and space on the block as the validator attempts to execute it. Depending on how the network was configured, the transaction fee may or may not be refunded, or a hold may placed on the paying purse. See [fee elimination](./fee-elimination.md) for more details.
 
-## How is cost determined?
+## How is gas cost determined?
 
-The amount of gas required for a transaction is determined by how much code is executed on the blockchain and the current average of all block utilization. Currently, gas is priced at a fixed price of 1 mote (1 CSPR is 10^9 motes) per 1 unit of gas. Cost is determined by the network's `current_gas_price` multiplier, which is dynamic and based on current network usage. A high rate of block utilization will increase the `current_gas_price` multiplier at the switch block, while low utilization will decrease the multiplier. There is both a minimum and a maximum potential multiplier, and all settings related to dynamic pricing can be configured in a Casper network's [chainspec](../glossary/C.md#chainspec).
-
-The gas charged for a transaction on the blockchain is paid to the network's validators.
+The amount of gas required for a transaction is determined by how much code is executed on the blockchain and the current average of all block utilization. Currently, gas is priced at a fixed price of 1 mote (1 CSPR is 10^9 motes) per 1 unit of gas. Cost is determined by the network's `current_gas_price` multiplier, which is dynamic and based on current network usage. A high rate of block utilization will increase the `current_gas_price` multiplier at the switch block, while low utilization will decrease the multiplier. There is both a minimum and a maximum potential multiplier, and all settings related to [dynamic pricing](../../concepts/economics/dynamic-gas-pricing.md) can be configured in a Casper network's [chainspec](../glossary/C.md#chainspec).
 
 ## Why do we need to charge a cost?
 
 Casper is a decentralized network of individual validators supplying their computational resources to keep the network live. As such, computations must be rate-limited and priced for the following reasons:
 
 -   Rate-limiting is used to ensure a secure and live network:
-    -   It prevents a specific kind of denial-of-service (DoS) attack. In computer networks, rate-limiting is used to control the rate of requests sent or received by a network to prevent DoS attacks. Gas behaves in a similar fashion, because each block permits only a fixed amount of transactions (gas) to be included in the era.
+    -   It prevents a specific kind of denial-of-service (DoS) attack. In computer networks, rate-limiting controls the rate of requests sent or received by a network to prevent DoS attacks. Gas behaves similarly, because each block permits only a fixed amount of transactions (gas) to be included in the era.
     -   It explicitly quantifies the system load. The cost helps us evaluate the use of computational resources and measure the amount of computational work that validators need to perform for each transaction. With this knowledge, we can specify minimum system requirements for validators.
 -   Pricing leads to more meaningful transactions:
-    -   Issuers of transactions and smart contract writers will be more aware of the limited network resources because there is a cost associated with each transaction. Pricing prevents users from spamming arbitrary amounts of empty transactions because there is a price to pay for each deploy.
-
-## Why do I see an ‘Out of gas error’?
-
-You might encounter an ‘Out of gas error’ when the gas payment you supplied for the transaction was insufficient to cover the actual cost of computation for the transaction. The amount of gas required for a transaction is determined by how much code is executed on the blockchain and also the storage utilized.
-
-Here is an [example](https://cspr.live/deploy/afeb43036c41e667af8bc34782c48a66cf4da3818defe9f761291fa515cc38b9) of a transaction resulting in an ‘Out of gas error’ on the Mainnet.
-
-**Figure 1**: In the Deploys tab of an account on [cspr.live](https://cspr.live/), a red exclamation mark is shown. By moving the cursor over it, the tooltip displays an 'Out of gas error'.
-
-<img src={useBaseUrl("/image/gas-concepts/error-deploys.png")} width="550" alt="Out of gas error" />
-
-**Figure 2**: Click the specific deploy to see more details such as the deploy hash, cost, and the status as an 'Out of gas error'. This indicates that the transaction did not have sufficient payment to cover the gas required for it to complete successfully.
-
-<img src={useBaseUrl("/image/gas-concepts/error-account.png")} width="550" alt="Gas error in account" />
-
-**Figure 3**: Click the **Show raw data** button, to see more details about the deploy. Towards the end of the raw data, you can see the error message.
-
-<img src={useBaseUrl("/image/gas-concepts/error-raw.png")} width="550" alt="Gas error in raw data" />
-
-## How do I determine the cost for a transaction?
-
-Currently, we are hard at work to create tools to help you estimate gas costs. Meanwhile, we recommend using the NCTL tool on your local machine or the [Testnet](https://testnet.cspr.live/) to [deploy your contracts](../../developers/cli/sending-transactions.md) in a test environment. You can check a deploy status and roughly see how much it would actually cost when deployed. You can estimate the costs in this way and then add a small buffer if the network state has changed. Note that when estimating cost locally or on the Testnet, the blockchain specification needs to match the specification of the Mainnet, where you will need to pay for the transaction with actual Casper (CSPR) tokens.
-
-## Why do I see a gas limit error?
-
-You may sometimes see an error such as _‘payment: 2.5, cost: 2.5, Error::GasLimit’_, This message seems to say that the transaction cost is 2.5 CSPR and you paid 2.5 CSPR, yet the transaction resulted in an error. Let’s explore this error message a little further.
-
-When a smart contract hits its gas limit (the payment amount), execution stops. If your limit is 2.5 CSPR, execution stops and that is the computation cost even if the smart contract did not run to completion. So, the error message tries to communicate to you that execution stopped at 2.5 CSPR. The computation resulted in an error because there were not enough funds to run to completion. It would have cost more than 2.5 CSPR to complete execution, but since you only supplied a payment of 2.5 CSPR worth of computation, the network stopped execution there and charged you that much, even though it was a failed transaction. The execution engine does not actually know how much it would have cost if allowed to run to completion, because it did not allow the contract to finish since the contract would have run over its gas limit.
+    -   Issuers of transactions and smart contract writers will be more aware of the limited network resources because there is a cost associated with each transaction. Pricing prevents users from spamming arbitrary amounts of empty transactions because there is a price to pay for each transaction.

--- a/cspr-docs/docs/concepts/economics/index.md
+++ b/cspr-docs/docs/concepts/economics/index.md
@@ -31,10 +31,9 @@ _Evictions_ deactivate validators who fail to participate in an era, deactivatin
 
 ## Runtime {#runtime}
 
-<!-- TODO provide specific wording that reflects the new dynamic pricing system for "spot" gas (you may have heard references to this as "block vacancy")-->
-The runtime layer encompasses the installation and execution of smart contracts, and other activities that alter the network's global state. This suggests potential markets for finite platform resources, such as markets for computing time and storage. Such markets could ensure that resources are allocated to their highest-value uses. Currently, however, we limit ourselves to [metering computing time](../design/casper-design.md#execution-semantics-gas), measured as gas. Gas can be conceptualized as the relative time use of different Wasm operations and host-side functions. The use of storage is also presently assigned a gas cost. A dynamic pricing system assigns the gas price and is described in more detail [here](./gas-concepts.md).
+The runtime layer encompasses the installation and execution of smart contracts and other activities that alter the network's global state. This suggests potential markets for finite platform resources, such as markets for computing time and storage. Such markets could ensure that resources are allocated to their highest-value uses. Currently, however, we limit ourselves to [metering computing time](../design/casper-design.md#execution-semantics-gas), measured as gas. Gas can be conceptualized as the relative time use of different Wasm operations and host-side functions. The use of storage is also presently assigned a gas cost.
 
-The initial Mainnet transaction selection mechanism is based on FIFO.
+The Mainnet transaction selection mechanism is based on FIFO.
 
 We expect to continue to work on runtime resource markets.
 
@@ -45,8 +44,18 @@ _Validators_ again play a vital role in this layer since protocol operation incl
 _Users_ execute session and contract code using the platform's computational resources
 
 ### Incentives (runtime layer) {#incentives-runtime-layer}
-<!--TODO explain the fee elimination model as a default, and therefore gas/balance holds will need to be discussed, again, probably, in a separate PR-->
-Gas/balance holds ensure that the users compensate validators for performing their computations.
+
+The Casper node software can be configured to support various fee, refund, and cost-handling strategies. The Condor release on Mainnet has enabled a [fee elimination](./fee-elimination.md) model by default, setting the `no_fee`,`no_refund`, and `fixed` pricing configurations in the network's chainspec.
+
+The `no_fee` mode means the token is put on hold instead of being taken from the payer. The hold interval is configured in the chainspec. The hold release mechanism is based on the "accrued" or "amortized" settings in the chainspec. Accrued holds are released after a certain amount of time has passed. Amortized holds are released using a linear schedule over a specified period.
+
+The `no_refund` mode means no refund is handled when fees are eliminated.
+
+Fixed pricing means the gas costs are determined using a cost table, and transactions are put in the appropriate lanes for execution. You can find more details about lanes [here](./runtime.md#lanes-lanes).
+
+When fees are eliminated, the block proposer receives validator credits instead of transaction fees. These credits contribute to the validator's total weight, determining their chances of winning a slot in the next era. Validators get rewards for proposing a block and creating and publishing finality signatures. In essence, gas/balance holds ensure that the network still compensates validators for their computations.
+
+The fee elimination model is different than the refund model introduced on Mainnet with release 1.5.6 and has replaced the refund behavior. Since all these behaviors are configurable, [private networks](../../operators/setup-network/create-private.md) can set their fee, refund, and pricing strategies.
 
 ## Ecosystem {#ecosystem}
 

--- a/cspr-docs/docs/concepts/economics/runtime.md
+++ b/cspr-docs/docs/concepts/economics/runtime.md
@@ -5,31 +5,88 @@ slug: /runtime
 
 # Runtime Economics
 
-The economics of the runtime layer should incentivize efficient allocation of computational resources, primarily CPU time, to users. <!--TODO add a bit more about state pruning here? -->
+The economics of the runtime layer should incentivize efficient allocation of computational resources, primarily CPU time, to users. The Condor release has introduced several new economic features:
 
-Currently, [gas](./gas-concepts.md) is allocated according to a first-in, first-out model for transactions. <!--TODO add a bit more about gas here? -->
+- A new mode of paying for computation in Mainnet, where tokens previously assessed as fees are now held for a predetermined period. Held tokens become available to users at the expiry of a predetermined time, or on a linear schedule over a specified period. Note: Increasing the duration of holds reduces the long-run equilibrium average available CSPR balance for an attacker. See [Fee Elimination](./fee-elimination.md) for more details.
+- A form of [dynamic pricing](#dynamic-gas-pricing) that increments or decrements the gas price in motes for a new era depending on blockchain utilization in the previous era.
+- Blocks are structured into [lanes](#lanes-lanes) that can only hold a particular number of transactions of specified types.
 
-## Gas allocation {#gas-allocation}
+These economic features are configurable using chainspec parameters.
 
-Any finite resource on a publicly accessible computer network must be rate-limited, as, otherwise, overuse of this resource is an attack vector \-- a minimal requirement for platform security. However, rate-limiting, implemented on our platform as a simple block gas limit with several lanes, leaves the platform with the problem of fairly and efficiently allocating the gas. We are researching the optimal structure for spot and futures gas markets, and interested readers should consult the relevant [CEPs](https://github.com/casper-network/ceps). In the meantime, this section outlines some basic features of the platform that would underpin any allocation scheme.
+<!--TODO add state pruning on this page? -->
+
+## Gas Allocation {#gas-allocation}
+
+Any finite resource on a publicly accessible computer network must be rate-limited, as, otherwise, overuse of this resource is an attack vector \-- a minimal requirement for platform security. However, rate-limiting, implemented on our platform as a simple block gas limit with several lanes, leaves the platform with the problem of fairly and efficiently allocating the [gas](./gas-concepts.md).
+
+We are researching the optimal structure for spot and futures gas markets, and interested readers should consult the relevant [CEPs](https://github.com/casper-network/ceps). In the meantime, this section outlines some basic features of the platform that would underpin any allocation scheme. Currently, gas is allocated according to a first-in, first-out transaction model.
 
 ### Consensus before execution & basics of payment {#consensus-before-execution--basics-of-payment}
 
-The Zug and Highway protocols reach consensus on a block _before_ the block is executed, introducing a subtle difference from platforms like Ethereum. In addition, transactions sent to a Casper network can only be selected based on claimed, rather than used, gas.
+The Zug and Highway protocols reach consensus on a block before it is executed, introducing a subtle difference from platforms like Ethereum. In addition, transactions sent to a Casper network can only be selected based on claimed rather than used gas.
 
 Additionally, a minimal amount of CSPR must be present in the user account or contract's main purse to cover the payment computation. The community may introduce additional balance checks in the future.
 
 ### Costs and limits {#costs-and-limits}
 
-Gas cost is a measure of the relative time used by different primitive operations of the execution engine, which is also assumed to be additive. By additivity, we mean that the time to execute a program is approximately proportional to the sum of gas expended by the opcodes and functions called within the program. Casper assigns gas costs to primitive execution engine opcodes and specific, more complex _host-side_ functions that are callable from within the execution engine context. Gas costs for opcodes and host-side functions are specified in the [chainspec](../glossary/C.md#chainspec) and may vary according to arguments.
+Gas cost is a measure of the relative time used by different primitive operations of the execution engine, which is also assumed to be additive. By additivity, we mean that the time to execute a program is approximately proportional to the sum of gas expended by the opcodes and functions called within the program. Casper assigns gas costs to primitive execution engine opcodes and specific, more complex _host-side_ functions that are callable from within the execution engine context. Gas costs for opcodes and host-side functions are specified in the [chainspec](../glossary/C.md#chainspec) and may vary according to arguments. Read more about how Casper measures computational work [here](../../concepts/design/casper-design.md#measuring-computational-work-execution-semantics-gas).
 
-<!--TODO remove this line? -->
-We expect to refine the current gas cost table to reflect time use more closely, with updates introduced in future upgrades.
+We expect to refine the current gas cost table to more closely reflect time use, with updates introduced in future upgrades.
 
-### Lanes {#lanes}
+### Lanes and gas costs {#lanes}
 
-The [block gas limit](https://github.com/casper-network/casper-node/blob/b94c4f79ac4ca00e996c418dcc3a98607779a193/resources/production/chainspec.toml#L96-L97) is split into two lanes, one for native transfers and one for general transactions. The number of transfers, which cost a fixed amount of gas, is governed directly by the `block_max_transfer_count` chainspec parameter, set to 2500 on Mainnet. <!--TODO check other lanes cost. -->
+There are several platform parameters that delineate the sets of transactions that may be included in a valid block:
 
-## Gas fees {#gas-fees}
+- **Number of lanes and lane types**
+   - System interaction lanes for Mint (transfers) and Auction transactions.
+   - WASM lanes serving transactions that carry opaque WASM. These lanes come with different slot sizes. Users need to specify a fixed quantity of gas for a transaction.
+   - All lanes can contain some finite number of transactions, set separately for each lane.
+   - For a call to a smart contract, the gas cost is always the same (given the transaction category), but the amount of CSPR that gets locked depends also on the gas price at the time.
+- **Block gas and size limits**
+   - The block gas limit imposes an absolute ceiling on how much gas can be allocated to the occupied slots.
+   - The block size limit imposes an absolute ceiling on the total byte size of included transactions.
+   - Individual transaction size limits are also enforced.
 
-See [Gas](./gas-concepts.md). <!--TODO Add a summary and point to new gas concepts page. Mention the new dynamic pricing system for "spot" gas (and "block vacancy"). -->
+These are the lane configuration settings for the Condor release on Mainnet:
+<!--TODO check and update these settings after the launch or link to the chainspec file directly.-->
+
+```toml
+[transactions.v1]
+# The configuration settings for the lanes of transactions including both native and Wasm based interactions.
+# Currently the node supports two native interactions the mint and auction and have the reserved identifiers of 0 and 1
+# respectively
+# The remaining wasm based lanes specify the range of configuration settings for a given Wasm based transaction
+# within a given lane.
+# The maximum length in bytes of runtime args per V1 transaction.
+# [0] -> Transaction lane label (apart from the reserved native identifiers these are simply labels)
+# Note: For the given mainnet implementation we specially reserve the label 2 for install and upgrades and
+# the lane must be present and defined.
+# Different casper networks may not impose such a restriction.
+# [1] -> Max transaction size in bytes for a given transaction in a certain lane
+# [2] -> Max args length size in bytes for a given transaction in a certain lane
+# [3] -> Transaction gas limit size in bytes for a given transaction in a certain lane
+# [4] -> The maximum number of transactions the lane can contain
+native_mint_lane = [0, 1024, 1024, 65_000_000_000, 650]
+native_auction_lane = [1, 2048, 2048, 362_500_000_000, 145]
+wasm_lanes = [[2, 1_048_576, 2048, 1_000_000_000_000, 1], [3, 344_064, 1024, 500_000_000_000, 3], [4, 172_032, 1024, 50_000_000_000, 7], [5, 12_288, 512, 1_500_000_000, 15]]
+```
+
+These are the block gas and size limits for the Condor release on Mainnet:
+<!--TODO check and update these settings after the launch or link to the chainspec file directly.-->
+
+```toml
+[transactions]
+...
+# Maximum block size in bytes including transactions contained by the block.  0 means unlimited.
+max_block_size = 5_242_880
+# The upper limit of total gas of all transactions in a block.
+block_gas_limit = 3_300_000_000_000
+```
+
+## Dynamic Gas Pricing
+
+A [dynamic gas pricing](./dynamic-gas-pricing.md) system assigns the gas price based on block vacancy (or consumption), preventing malicious actors from flooding the network with useless transactions and ensuring network integrity. Dynamic gas pricing acts as a supply and demand-based check on the cost of network usage. If usage is low, the price multiple drifts down over time, incentivizing casual usage. If usage is high, the price multiple climbs up, incentivizing prioritized usage. Dynamic gas pricing also protects against long-range consumption attacks. An attacker attempting to fill blocks to deny usage drives the price up, which requires them to have increasing amounts of tokens available to cover rising gas costs to maintain their attack.
+
+## Eliminating Gas Fees {#gas-fees}
+
+See [Gas](./gas-concepts.md) and [Fee Elimination](./fee-elimination.md) for more details.

--- a/cspr-docs/docs/concepts/glossary/D.md
+++ b/cspr-docs/docs/concepts/glossary/D.md
@@ -33,3 +33,7 @@ Review the [deploy data structure](../serialization/structures.md#deploy) and th
 A `Dictionary` is a storage data structure on a Casper network. Dictionaries represent a more efficient and scalable form of data storage when compared to [`NamedKeys`](./N.md#namedkeys).
 
 More information can be found in the [Reading and Writing to Dictionaries](../dictionaries.md) document.
+
+## Dynamic gas pricing {#dynamic-gas-pricing}
+
+Dynamic gas pricing acts as a supply and demand-based check on the cost of network usage. If usage is low, the price multiple drifts down over time, incentivizing casual usage. If usage is high, the price multiple climbs up, incentivizing prioritized usage. Find more details [here](../economics/dynamic-gas-pricing.md).

--- a/cspr-docs/docs/concepts/glossary/G.md
+++ b/cspr-docs/docs/concepts/glossary/G.md
@@ -8,7 +8,15 @@
 
 ## Gas {#gas}
 
-Gas is the virtual currency for calculating the cost of transaction execution. The transaction cost is expressed as a given amount of gas consumed and can be seen intuitively as some cycles of the virtual processor that has to be used to run the computation defined as the transaction's code.
+Gas is a conceptual measure of resources used when executing transactions on the blockchain.
+
+## Gas cost {#gas-cost}
+
+Gas cost is the amount of gas consumed during the processing cycles that execute a transaction on the network. It is directly correlated with the amount of computer processing a validator needs to provide to execute a transaction.
+
+## Gas price {#gas-price}
+
+Multiplier applied to gas cost. See [dynamic gas pricing](../economics/dynamic-gas-pricing.md).
 
 ## Genesis {#genesis}
 

--- a/cspr-docs/docs/concepts/glossary/P.md
+++ b/cspr-docs/docs/concepts/glossary/P.md
@@ -42,10 +42,6 @@ Proof-of-Stake (PoS) is a mechanism by which a cryptocurrency blockchain network
 
 A mechanism used in Bitcoin and Etherium for incentivizing participation and securing the system. In these protocols, a participant's voting power is proportional to the amount of computational power possessed.
 
-## Proof-of-Stake contract {#proof-of-stake-contract}
-
-The Proof-of-Stake (PoS) contract holds on to transaction fees for the time while the state transition is happening (contracts are being executed). The PoS contract remits the transaction fees to the block proposer.
-
 ## Proposer {#proposer}
 The proposer is a selected validator by a Casper network to propose the next block. A validator becomes a proposer by proposing a block to be added to the chain and receiving the appropriate reward. The proposing process assures that new blocks will be added to the blockchain.
 

--- a/cspr-docs/docs/concepts/glossary/S.md
+++ b/cspr-docs/docs/concepts/glossary/S.md
@@ -40,7 +40,7 @@ A smart contract platform provides the required blockchain environment for the c
 
 ## Staker {#staker}
 
-A person that deposits tokens in the [proof-of-stake](./P.md#proof-of-stake) contract. A staker is either a [validator](./V.md#validator) or a [delegator](./D.md#delegator). Stakers take on the slashing risk in exchange for rewards. Stakers will deposit their [tokens](./T.md#token) by sending a bonding request in the form of a transaction (deployment) to the system. If a validator is [slashed](#slashing), the staker will lose their tokens.
+A staker is either a [validator](./V.md#validator) or a [delegator](./D.md#delegator). Stakers take on the slashing risk in exchange for rewards. Stakers will deposit their [tokens](./T.md#token) by sending a bonding request in the form of a transaction (deployment) to the system. If a validator is [slashed](#slashing), the staker will lose their tokens.
 
 ## Staking {#staking}
 

--- a/cspr-docs/docs/developers/cli/opcode-costs.md
+++ b/cspr-docs/docs/developers/cli/opcode-costs.md
@@ -11,14 +11,14 @@ More information on `chainspec`s for private networks can be found [here](/opera
 :::note
 
 All costs in this table are in [motes](/concepts/glossary/M/#motes), not CSPR, and the corresponding chainspec is [here](https://github.com/casper-network/casper-node/blob/53dd33865c2707c29284ccc0e8485f22ddd6fbe3/resources/production/chainspec.toml#L129).
-
+<!--TODO update the link when 2.0 ships to Testnet/Mainnet. -->
 :::
 
 ## Storage Costs
 
 |Attribute         |Description                                    | Cost |
 |----------------- |-----------------------------------------------|-----------------|
-|gas_per_byte | Gas charged per byte stored in global state. | 630,000|
+|gas_per_byte | Gas charged per byte stored in global state. | 1_117_587|
 
 ## OpCode Costs
 
@@ -29,7 +29,7 @@ All costs in this table are in [motes](/concepts/glossary/M/#motes), not CSPR, a
 |mul |  Mul operations multiplier. | 240|
 |div | Div operations multiplier. | 320|
 |load | Memory load operation multiplier. | 2_500|
-|store |Memory store operation multiplier. | 4,700|
+|store |Memory store operation multiplier. | 4_700|
 |const | Const store operation multiplier. | 110|
 |local | Local operations multiplier. | 390|
 |global | Global operations multiplier. | 390|
@@ -38,7 +38,7 @@ All costs in this table are in [motes](/concepts/glossary/M/#motes), not CSPR, a
 |unreachable | Unreachable operation multiplier. | 270|
 |nop | Nop operation multiplier. | 200|
 |current_memory | Get the current memory operation multiplier. | 290|
-|grow_memory | Grow memory cost per page (64 kB). | 240,000|
+|grow_memory | Grow memory cost per page (64 kB). | 240_000|
 
 ## Control Flow Operation Costs
 
@@ -50,18 +50,18 @@ All costs in this table are in [motes](/concepts/glossary/M/#motes), not CSPR, a
 |else | Cost for `else` opcode. | 440|
 |end | Cost for `end` opcode. | 440|
 |br | Cost for `br` opcode. | 35_000|
-|br_if | Cost for `br_if` opcode. | 35,000|
+|br_if | Cost for `br_if` opcode. | 35_000|
 |return | Cost for `return` opcode. | 440|
 |select | Cost for `select` opcode. | 440|
 |call | Cost for `call` opcode. | 68_000|
-|call_indirect | Cost for `call_indirect` opcode. | 68,000|
+|call_indirect | Cost for `call_indirect` opcode. | 68_000|
 |drop | Cost for `drop` opcode. | 440|
 
 ## `Br_Table` OpCode Costs
 
 |Attribute         |Description                                    | Cost |
 |----------------- |-----------------------------------------------|-----------------|
-|cost | Fixed cost per `br_table` opcode. | 35,000|
+|cost | Fixed cost per `br_table` opcode. | 35_000|
 |size_multiplier |  Size of target labels in the `br_table` opcode will be multiplied by `size_multiplier`. | 100|
 
 ## External Function Costs
@@ -70,55 +70,53 @@ The following costs are for low-level bindings for host-side ("external") functi
 
 |Host-Side Function| Cost | Arguments |
 | ---------------- | ---- | --------- |
-| add | 5,800 | [0, 0, 0, 0] |
-| add_associated_key | 9,000 | [0, 0, 0] |
-| add_contract_version | 200 | [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] |
-| blake2b | 200 | [0, 0, 0, 0] |
-| call_contract | 4,500 | [0, 0, 0, 0, 0, 420, 0] |
-| call_versioned_contract | 4,500 | [0, 0, 0, 0, 0, 0, 0, 420, 0] |
+| add | 5_800 | [0, 0, 0, 0] |
+| add_associated_key | 1_200_000 | [0, 0, 0] |
+| add_contract_version | 200 | [0, 0, 0, 0, 120_000, 0, 0, 0, 30_000, 0, 0] |
+| blake2b | 1_200_000 | [0, 120_000, 0, 0] |
+| call_contract | 300_000_000 | [0, 0, 0, 120_000, 0, 120_000, 0] |
+| call_versioned_contract | 300_000_000 | [0, 0, 0, 0, 120_000, 0, 120_000, 0] |
 | create_contract_package_at_hash | 200 | [0, 0] |
 | create_contract_user_group | 200 | [0, 0, 0, 0, 0, 0, 0, 0] |
-| create_purse | 2,500,000,000 | [0, 0] |
+| create_purse | 2_500_000_000 | [0, 0] |
 | disable_contract_version | 200 | [0, 0, 0, 0] |
-| get_balance | 3,800 | [0, 0, 0] |
+| get_balance | 3_000_000 | [0, 0, 0] |
 | get_blocktime | 330 | [0] |
 | get_caller | 380 | [0] |
-| get_key | 2,000 | [0, 440, 0, 0, 0] |
-| get_main_purse | 1,300 | [0] |
-| get_named_arg | 200 | [0, 0, 0, 0] |
+| get_key | 2_000 | [0, 440, 0, 0, 0] |
+| get_main_purse | 1_300 | [0] |
+| get_named_arg | 200 | [0, 120_000, 0, 120_000] |
 | get_named_arg_size | 200 | [0, 0, 0] |
 | get_phase | 710 | [0] |
-| get_system_contract | 1,100 | [0, 0, 0] |
-| has_key | 1,500 | [0, 840] |
+| get_system_contract | 1_100 | [0, 0, 0] |
+| has_key | 1_500 | [0, 840] |
 | is_valid_uref | 760 | [0, 0] |
-| load_named_keys | 42,000 | [0, 0] |
-| new_uref | 17,000 | [0, 0, 590] |
+| load_named_keys | 42_000 | [0, 0] |
+| new_uref | 17_000 | [0, 0, 590] |
 | random_bytes | 200 | [0, 0] |
-| print | 20,000 | [0, 4,600] |
+| print | 20_000 | [0, 4_600] |
 | provision_contract_user_group_uref | 200 | [0, 0, 0, 0, 0] |
-| put_key | 38,000 | [0, 1,100, 0, 0] |
-| read_host_buffer | 3,500 | [0, 310, 0] |
-| read_value | 6,000 | [0, 0, 0] |
-| read_value_local | 5,500 | [0, 590, 0] |
-| remove_associated_key | 4,200 | [0, 0] |
+| put_key | 100_000_000 | [0, 120_000, 0, 120_000] |
+| read_host_buffer | 3_500 | [0, 310, 0] |
+| read_value | 60_000 | [0, 120_000, 0] |
+| read_value_local | 5_500 | [0, 590, 0] |
+| remove_associated_key | 4_200 | [0, 0] |
 | remove_contract_user_group | 200 | [0, 0, 0, 0] |
-| remove_contract_user_group_urefs | 200 | [0, 0, 0, 0, 0, 0] |
-| remove_key | 61,000 | [0, 3,200] |
-| ret | 23,000 | [0, 420,000] |
+| remove_contract_user_group_urefs | 200 | [0, 0, 0, 0, 0, 120_000] |
+| remove_key | 61_000 | [0, 3_200] |
+| ret | 23_000 | [0, 420_000] |
 | revert | 500 | [0] |
-| set_action_threshold | 74,000 | [0, 0] |
-| transfer_from_purse_to_account | 2,500,000,000 | [0, 0, 0, 0, 0, 0, 0, 0, 0] |
-| transfer_from_purse_to_purse | 82,000 | [0, 0, 0, 0, 0, 0, 0, 0] |
-| transfer_to_account | 2,500,000,000 | [0, 0, 0, 0, 0, 0, 0] |
-| update_associated_key | 4,200 | [0, 0, 0] |
-| write | 14,000 | [0, 0, 0, 980] |
-| write_local | 9,500 | [0, 1,800, 0, 520] |
-
-## Protocol Operating Costs
-
-|Attribute         |Description                                    | Cost |
-|----------------- |-----------------------------------------------|-----------------|
-|wasmless_transfer_cost | Default gas cost for a wasmless transfer. | 100,000,000|
+| set_action_threshold | 74_000 | [0, 0] |
+| transfer_from_purse_to_account | 2_500_000_000 | [0, 0, 0, 0, 0, 0, 0, 0, 0] |
+| transfer_from_purse_to_purse | 82_000_000 | [0, 0, 0, 0, 0, 0, 0, 0] |
+| transfer_to_account | 2_500_000_000 | [0, 0, 0, 0, 0, 0, 0] |
+| update_associated_key | 4_200 | [0, 0, 0] |
+| write | 14_000 | [0, 0, 0, 980] |
+| dictionary_put | 9_500 | [0, 1_800, 0, 520] |
+| enable_contract_version | 200 | [0, 0, 0, 0] |
+| manage_message_topic | 200 | [0, 30_000, 0, 0] |
+| emit_message | 200 | [0, 30_000, 0, 120_000] |
+| cost_increase_per_message | 50 | |
 
 ### `Auction` System Contract Costs
 
@@ -126,20 +124,21 @@ These are the costs of calling `auction` system contract entrypoints.
 
 |Entrypoint         |Description                                    | Cost |
 |----------------- |-----------------------------------------------|-----------------|
-|get_era_validators | Cost of calling the `get_era_validators` entrypoint. | 10,000|
-|read_seigniorage_recipients | Cost of calling the `read_seigniorage_recipients` entrypoint. | 10,000|
-|add_bid | Cost of calling the `add_bid` entrypoint. | 2,500,000,000|
-|withdraw_bid | Cost of calling the `withdraw_bid` entrypoint. | 2,500,000,000|
-|delegate | Cost of calling the `delegate` entrypoint. | 2,500,000,000|
-|undelegate | Cost of calling the `undelegate` entrypoint. | 2,500,000,000|
-|run_auction | Cost of calling the `run_auction` entrypoint. | 10,000|
-|slash | Cost of calling the `slash` entrypoint. | 10,000|
-|distribute | Cost of calling the `distribute` entrypoint. | 10,000|
-|withdraw_delegator_reward | Cost of calling the `withdraw_delegator_reward` entrypoint. | 10,000|
-|withdraw_validator_reward | Cost of calling the `withdraw_validator_reward` entrypoint. | 10,000|
-|read_era_id | Cost of calling the `read_era_id` entrypoint. | 10,000|
-|activate_bid | Cost of calling the `activate_bid` entrypoint. | 10,000|
-|redelegate | Cost of calling the `redelegate` entrypoint. | 2,500,000,000|
+|get_era_validators | Cost of calling the `get_era_validators` entrypoint. | 10_000|
+|read_seigniorage_recipients | Cost of calling the `read_seigniorage_recipients` entrypoint. | 10_000|
+|add_bid | Cost of calling the `add_bid` entrypoint. | 2_500_000_000|
+|withdraw_bid | Cost of calling the `withdraw_bid` entrypoint. | 2_500_000_000|
+|delegate | Cost of calling the `delegate` entrypoint. | 2_500_000_000|
+|undelegate | Cost of calling the `undelegate` entrypoint. | 2_500_000_000|
+|run_auction | Cost of calling the `run_auction` entrypoint. | 10_000|
+|slash | Cost of calling the `slash` entrypoint. | 10_000|
+|distribute | Cost of calling the `distribute` entrypoint. | 10_000|
+|withdraw_delegator_reward | Cost of calling the `withdraw_delegator_reward` entrypoint. | 10_000|
+|withdraw_validator_reward | Cost of calling the `withdraw_validator_reward` entrypoint. | 10_000|
+|read_era_id | Cost of calling the `read_era_id` entrypoint. | 10_000|
+|activate_bid | Cost of calling the `activate_bid` entrypoint. | 10_000|
+|redelegate | Cost of calling the `redelegate` entrypoint. | 2_500_000_000|
+|change_bid_public_key | Cost of calling the `change_bid_public_key` entrypoint. | 5_000_000_000 |
 
 ### `Mint` System Contract Costs
 
@@ -147,13 +146,14 @@ These are the costs of calling `mint` system contract entrypoints.
 
 |Entrypoint         |Description                                    | Cost |
 |----------------- |-----------------------------------------------|-----------------|
-|mint | Cost of calling the `mint` entrypoint. | 2,500,000,000|
-|reduce_total_supply | Cost of calling the `reduce_total_supply` entrypoint. | 10,000|
-|create | Cost of calling the `create` entrypoint. | 2,500,000,000|
-|balance | Cost of calling the `balance` entrypoint. | 10,000|
-|transfer | Cost of calling the `transfer` entrypoint. | 10,000|
-|read_base_round_reward | Cost of calling the `read_base_round_reward` entrypoint. | 10,000|
-|mint_into_existing_purse | Cost of calling the `mint_into_existing_purse` entrypoint. | 2,500,000,000|
+|mint | Cost of calling the `mint` entrypoint. | 2_500_000_000|
+|reduce_total_supply | Cost of calling the `reduce_total_supply` entrypoint. | 10_000|
+|create | Cost of calling the `create` entrypoint. | 2_500_000_000|
+|balance | Cost of calling the `balance` entrypoint. | 10_000|
+|burn | Cost of calling the `burn` entrypoint. | 10_000|
+|transfer | Cost of calling the `transfer` entrypoint. | 10_000|
+|read_base_round_reward | Cost of calling the `read_base_round_reward` entrypoint. | 10_000|
+|mint_into_existing_purse | Cost of calling the `mint_into_existing_purse` entrypoint. | 2_500_000_000|
 
 
 ### `Handle_Payment` System Contract Costs
@@ -162,10 +162,10 @@ These are the costs of calling entrypoints on the `handle_payment` system contra
 
 |Entrypoint         |Description                                    | Cost |
 |----------------- |-----------------------------------------------|-----------------|
-|get_payment_purse | Cost of calling the `get_payment_purse` entrypoint. |10,000|
-|set_refund_purse  | Cost of calling the `set_refund_purse` entrypoint. |10,000|
-|get_refund_purse  | Cost of calling the `get_refund_purse` entrypoint. |10,000|
-|finalize_payment  | Cost of calling the `finalize_payment` entrypoint. |10,000|
+|get_payment_purse | Cost of calling the `get_payment_purse` entrypoint. |10_000|
+|set_refund_purse  | Cost of calling the `set_refund_purse` entrypoint. |10_000|
+|get_refund_purse  | Cost of calling the `get_refund_purse` entrypoint. |10_000|
+|finalize_payment  | Cost of calling the `finalize_payment` entrypoint. |10_000|
 
 ### `Standard_Payment` System Contract Costs
 
@@ -173,4 +173,4 @@ These settings manage the costs of calling entrypoints on the `standard_payment`
 
 |Entrypoint        |Description                                    | Cost |
 |----------------- |-----------------------------------------------|-----------------|
-|pay| Cost of calling the `pay` entrypoint and sending an amount to a payment purse. |10,000|
+|pay| Cost of calling the `pay` entrypoint and sending an amount to a payment purse. |10_000|

--- a/cspr-docs/docs/developers/cli/sending-transactions.md
+++ b/cspr-docs/docs/developers/cli/sending-transactions.md
@@ -2,6 +2,8 @@
 title: Sending Transactions
 ---
 
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
 # Sending Transactions using the Casper Client
 
 To install smart contracts on the blockchain, you can send your Wasm to the network via a [Transaction](../../concepts/glossary/T.md#transaction-transaction). To do this, you will need to meet a few prerequisites:
@@ -26,7 +28,7 @@ If you want to follow the [lifecycle](../../concepts/design/casper-design.md#exe
 
 - The IP address of a [peer](../prerequisites.md#acquire-node-address-from-network-peers) on the network
 - The port specified as the `event_stream_server.address` in the node's *config.toml*, which is by default 9999 on Mainnet and Testnet
-- The URL for streamed events, which is \<HOST:PORT\>/events
+- The URL for streamed events, which is <HOST:PORT>/events
 
 With the following command, you can start watching the event stream. Note the event ID recorded when you send the Transaction in the next section.
 
@@ -1331,7 +1333,7 @@ If the Transaction succeeded, the `get-txn` command would return a JSON object w
 
 We want to draw your attention to a few properties in the example output:
 
-- Execution consumed 371736413663 motes, which is less than our `gas price tolerance` of 1000000000000. See the [note about gas price](#a-note-about-gas-price)
+- Execution consumed 371736413663 motes, which is less than our `gas price tolerance` of 1000000000000. Read about [gas cost for transactions](#gas-cost-for-transactions)
 - The contract returned no errors. If you see an "Out of gas error", you did not specify a high enough value in the `--gas-price-tolerance` arg
 - The time-to-live was 30 minutes
 
@@ -1403,7 +1405,7 @@ To sign a Transaction with multiple keys, create the Transaction with the `make-
 
 For a step-by-step workflow, visit the [Two-Party Multi-Signature Transaction](../cli/transfers/multisig-deploy-transfer.md) guide. This workflow describes how a trivial two-party multi-signature scheme for signing and sending transactions can be enforced for an account on a Casper network.
 
-## A Note about Gas Price {#a-note-about-gas-price}
+## Gas Cost for Transactions {#gas-cost-for-transactions}
 
 A common question frequently arises: "How do I know what the payment amount (gas cost) should be?"
 
@@ -1411,16 +1413,42 @@ We recommend installing your contracts in a test environment, making sure the co
 
 :::note
 
-Casper's "Condor" release introduces a new payment system that that includes the concept of fee elimination. More information can be found here.
+Casper's "Condor" release introduces a new payment system that includes the concept of [fee elimination](../../concepts/economics/fee-elimination.md).
 
 :::
 
-<!--TODO Include a link to fee elimination docs when available.-->
-
 If your test configuration matches your production [chainspec](../../concepts/glossary/C.md#chainspec), you can check the transaction status and roughly see how much it would cost. You can estimate the costs in this way and then add a small buffer to be sure. Refer to the [runtime economics](../../concepts/economics/runtime.md#gas-allocation) section for more details about gas usage and fees.
 
-Please be aware that sending a transaction always requires payment. This is true regardless of the validity of included Wasm.
+Please be aware that sending a transaction always requires payment. This is true regardless of the validity of included Wasm. Depending on how the network was configured, the transaction payment may or may not be refunded, or a hold may placed on the paying purse. See [fee elimination](../../concepts/economics/fee-elimination.md) for more details.
 
 If the transaction failure occurs after session execution begins, the penalty payment of 2.5 CSPR is included in the gas costs of the [failed execution](../../concepts/serialization/types.md#executionresultv2).
 
-However, if the failure occurs prior to session execution, the penalty payment will not appear within the gas cost of the transaction. Instead, the system automatically deducts the 2.5 CSPR from the sending account's main purse.
+However, if the failure occurs prior to session execution, the penalty payment will not appear in the transaction's gas cost. Depending on the network configuration, the system will deduct the processing fee from the sending account's main purse or place a processing hold on the purse.
+
+## Common Errors Related to Payments
+
+### Out of gas error
+
+You might encounter an "Out of gas error" when the gas payment you supplied for the transaction was insufficient to cover the actual cost of computation for the transaction. The amount of gas required for a transaction is determined by how much code is executed on the blockchain and also the storage utilized.
+
+Here is an [example](https://cspr.live/deploy/afeb43036c41e667af8bc34782c48a66cf4da3818defe9f761291fa515cc38b9) of a transaction that resulted in an "Out of gas error" on the Mainnet.
+
+**Figure 1**: In the Deploys tab of an account on [cspr.live](https://cspr.live/), a red exclamation mark is shown. By moving the cursor over it, the tooltip displays an "Out of gas error".
+
+<img src={useBaseUrl("/image/gas-concepts/error-deploys.png")} width="550" alt="Out of gas error" />
+
+**Figure 2**: Click the specific deploy to see more details such as the deploy hash, cost, and the status as an 'Out of gas error'. This indicates that the transaction did not have sufficient payment to cover the gas required for it to complete successfully.
+
+<img src={useBaseUrl("/image/gas-concepts/error-account.png")} width="550" alt="Gas error in account" />
+
+**Figure 3**: Click the **Show raw data** button, to see more details about the deploy. Towards the end of the raw data, you can see the error message.
+
+<img src={useBaseUrl("/image/gas-concepts/error-raw.png")} width="550" alt="Gas error in raw data" />
+
+### Gas limit error
+
+You may sometimes see an error such as "payment: 2.5, cost: 2.5, Error::GasLimit". This message seems to say that the transaction cost is 2.5 CSPR and you paid 2.5 CSPR, yet the transaction resulted in an error.
+
+This error message tries to communicate that execution stopped at 2.5 CSPR, and the transaction did not run to completion. In other words, the computation resulted in an error because there were insufficient funds for the transaction to run to completion. It would have cost more than 2.5 CSPR to complete execution, but since you only supplied a payment of 2.5 CSPR worth of computation, the network stopped execution and charged that much, resulting in a failed transaction. The execution engine does not know how much it would have cost if allowed to run to completion because it did not allow the transaction to finish since it would have run over its gas limit.
+
+In summary, when a transaction hits its gas limit (the payment amount), execution stops.

--- a/cspr-docs/docs/developers/dapps/nctl-test.md
+++ b/cspr-docs/docs/developers/dapps/nctl-test.md
@@ -42,7 +42,7 @@ You will need the following information to use the `put-deploy` command:
 
 * The **secret key** of the account sending the `Deploy`. For this example, we are using node-1 as the sender. The secret key file can be found at *casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem*. In our example put-deploy, this will appear as `--secret-key /casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem`. If your Deploy is more complex and requires multiple accounts, NCTL also establishes multiple users for testing.
 
-* The **payment amount** in motes, which should be sufficient to avoid an 'Out of Gas' error. The payment amount will appear in our example put-deploy as `--payment-amount 2500000000`. **NCTL tests are not an accurate representation of potential gas costs on a live network. Please see our [note about gas prices](../../developers/cli/sending-transactions.md#a-note-about-gas-price).**
+* The **payment amount** in motes, which should be sufficient to avoid an 'Out of Gas' error. The payment amount will appear in our example put-deploy as `--payment-amount 2500000000`. **NCTL tests are not an accurate representation of potential gas costs on a live network. Please read about [gas cost for transactions](../../developers/cli/sending-transactions.md#gas-cost-for-transactions).**
 
 * The **path** to your `Deploy` that you wish to send to the NCTL network. This will appear in our example put-deploy as `--session-path <PATH>` and will require you to define the path to your specific `Deploy` Wasm.
 

--- a/cspr-docs/docs/operators/setup-network/chain-spec.md
+++ b/cspr-docs/docs/operators/setup-network/chain-spec.md
@@ -4,7 +4,7 @@ title: The Chainspec
 
 # The Blockchain Specification {#the-chain-specification}
 
-The blockchain specification, or `chainspec`, is a collection of configuration settings describing the network state at genesis and upgrades to basic system functionality (including system contracts and gas costs) occurring after genesis. This page describes each field in the chainspec, based on [version 1.5.2](https://github.com/casper-network/casper-node/blob/release-1.5.2/resources/production/chainspec.toml) of the Casper node. The chainspec can and should be customized for private networks. The chainspec attributes are divided into categories based on what they are configuring.
+The blockchain specification, or `chainspec`, is a collection of configuration settings describing the network state at genesis and upgrades to basic system functionality (including system contracts and gas costs) occurring after genesis. This page describes each field in the chainspec, based on version 2.0.0 of the Casper node. The chainspec can and should be customized for private networks. The chainspec attributes are divided into categories based on what they are configuring. <!--TODO add link to 2.0 release version when available -->
 
 ## protocol
 
@@ -12,9 +12,9 @@ These settings describe the active protocol version.
 
 |Attribute         |Description                                    | Mainnet Setting |
 |----------------- |-----------------------------------------------|-----------------|
-|version          | The Casper node protocol version. | '1.5.2'|
+|version          | The Casper node protocol version. | '2.0.0'|
 |hard_reset       | When set to true, clear blocks and transactions back to the switch block (the end of the last era) just before the activation point. Used during the upgrade process to reset the network progress. In most cases, this setting should be true.| true|
-|activation_point | The protocol version that should become active. <br /><br />If it is a timestamp string, it represents the timestamp for the genesis block. This is the beginning of Era 0. By this time, a sufficient majority (> 50% + F/2 — see the `finality_threshold_fraction` below) of validator nodes must be running to start the blockchain. This timestamp is also used in seeding the pseudo-random number generator used in the contract runtime for computing the genesis post-state hash. <br /><br />If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era. | 9100|
+|activation_point | The protocol version that should become active. <br /><br />If it is a timestamp string, it represents the timestamp for the genesis block. This is the beginning of Era 0. By this time, a sufficient majority (> 50% + F/2 — see the `finality_threshold_fraction` below) of validator nodes must be running to start the blockchain. This timestamp is also used in seeding the pseudo-random number generator used in the contract runtime for computing the genesis post-state hash. <br /><br />If it is an integer, it represents an era ID, meaning the protocol version becomes active at the start of this era. | 11100|
 
 
 ## network
@@ -32,22 +32,25 @@ These settings manage the core protocol behavior.
 
 |Attribute         |Description                                    | Mainnet Setting |
 |----------------- |-----------------------------------------------|-----------------|
-|era_duration | Era duration. | '120min'|
+|era_duration | Era duration. | '120 minutes'|
 |minimum_era_height | Minimum number of blocks per era. An era will take longer than `era_duration` if that is necessary to reach the minimum height. | 20 | 
-|minimum_block_time | Minimum difference between a block's and its child's timestamp. | '16384ms'|
+|minimum_block_time | Minimum difference between a block's and its child's timestamp. | '16384 ms'|
 |validator_slots | Number of slots available in the validator auction. | 100|
 |finality_threshold_fraction | A number between 0 and 1 representing the fault tolerance threshold as a fraction used by the internal finalizer.<br />It is the fraction of validators that would need to equivocate to make two honest nodes see two conflicting blocks as finalized.<br />Let's say this value is F. A higher value F makes it safer to rely on finalized blocks. It also makes it more difficult to finalize blocks, however, and requires strictly more than (F + 1)/2 validators to be working correctly. | [1, 3]|
 |start_protocol_version_with_strict<br />_finality_signatures_required |Protocol version from which nodes are required to hold strict finality signatures.| '1.5.0'|
 |legacy_required_finality|The finality required for legacy blocks. Options are 'Strict', 'Weak', and 'Any'. <br />Used to determine finality sufficiency for new joiners syncing blocks created in a protocol version before the start protocol version with strict finality signatures. |'Strict'|
+|migrate_legacy_accounts| If true, the protocol upgrade will migrate ALL user accounts to addressable entity. If false, user accounts will be left as they are and will be lazily migrated on a per-account basis if / when that account is used during transaction execution. | true|
+|migrate_legacy_contracts| If true, the protocol upgrade will migrate ALL user contracts to addressable entity. If false, user contracts will be left as they are and will be lazily migrated on a per-contract basis if / when that contract is used during transaction execution. | true|
 |auction_delay | Number of eras before an auction defines the set of validators. If a validator bonds with a sufficient bid in era N, it will be a validator in era N + auction_delay + 1. | 1|
-|locked_funds_period | The period after genesis during which a genesis validator's bid is locked. | '90days'|
-|vesting_schedule_period | The period in which the genesis validator's bid is released over time after it is unlocked. | '13 weeks'|
+|locked_funds_period | The period after genesis during which a genesis validator's bid is locked. | '0 days'|
+|vesting_schedule_period | The period in which the genesis validator's bid is released over time after it is unlocked. | '0 weeks'|
 |unbonding_delay | Default number of eras that need to pass to be able to withdraw unbonded funds. | 7|
-|round_seigniorage_rate | Round seigniorage rate represented as a fraction of the total supply.<br />- Annual issuance: 8%.<br />- Minimum block time: 2^15 milliseconds.<br />- Ticks per year: 31536000000.<br /><br />(1+0.08)^((2^15)/31536000000)-1 is expressed as a fractional number below in Python:<br />`Fraction((1 + 0.08)**((2**15)/31536000000) - 1).limit_denominator(1000000000)` | [7, 87535408]|
+|round_seigniorage_rate | Round seigniorage rate represented as a fraction of the total supply.<br />- Annual issuance: 8%.<br />- Minimum block time: 2^15 milliseconds.<br />- Ticks per year: 31536000000.<br /><br />(1+0.08)^((2^15)/31536000000)-1 is expressed as a fractional number below in Python:<br />`Fraction((1 + 0.08)**((2**15)/31536000000) - 1).limit_denominator(1000000000)` | [7, 175070816]|
 |max_associated_keys | Maximum number of associated keys for a single account. | 100|
 |max_runtime_call_stack_height | Maximum height of the contract runtime call stack. | 12|
 |minimum_delegation_amount | Minimum allowed delegation amount in motes. | 500_000_000_000|
-|prune_batch_size | Global state prune batch size for tip pruning in version 1.4.15. Possible values:<br />- 0 when the feature is OFF<br />- Integer if the feature is ON, representing the number of eras to process per block.| 0|
+|maximum_delegation_amount | Maximum allowed delegation amount in motes. | 1_000_000_000_000_000_000|
+|prune_batch_size | Global state prune batch size for tip pruning. Possible values:<br />- 0 when the feature is OFF<br />- Integer if the feature is ON, representing the number of eras to process per block.| 0|
 |strict_argument_checking | Enables strict arguments checking when calling a contract; i.e., all non-optional args are provided and they are of the correct `CLType`. | false|
 |simultaneous_peer_requests | Number of simultaneous peer requests. | 5|
 |consensus_protocol | The consensus protocol to use. Options are 'Zug' or 'Highway'. | 'Zug'|
@@ -55,6 +58,19 @@ These settings manage the core protocol behavior.
 |finders_fee | The split in finality signature rewards between block producer and participating signers. | [1, 5]|
 |finality_signature_proportion | The proportion of baseline rewards going to reward finality signatures specifically. | [1, 2]|
 |signature_rewards_max_delay | Lookback interval indicating how many past blocks we are looking at to reward. | 3|
+|allow_unrestricted_transfers | Allows peer to peer transfers between users. Setting this to false makes sense only for private chains.| true|
+|allow_auction_bids | Enables the auction entry points 'delegate' and 'add_bid'. Setting this to false makes sense only for private chains that don't need to auction new validator slots. These auction entry points will return an error if called, when this option is set to false. | true|
+|compute_rewards | If set to false, then consensus doesn't compute rewards and always uses 0. | true|
+|refund_handling | Defines how refunds of the unused portion of payment amounts are calculated and handled. Valid options are: refund (a ratio of the unspent token is returned to the spender); burn (a ratio of the unspent token is burned); no_refund (no refunds are paid out) | { type = 'no_refund' }|
+|fee_handling    | Defines how fees are handled. Valid options are: no_fee (fees are eliminated); pay_to_proposer (fees are paid to the block proposer); accumulate (fees are accumulated in a special purse and distributed at the end of each era evenly among all administrator accounts); burn (fees are burned) | { type = 'no_fee' }   |
+|validator_credit_cap | If a validator would recieve a validator credit, it cannot exceed this percentage of their total stake. | [1, 5] |
+|pricing_handling | Defines how pricing is handled. Valid options are: classic (senders of transaction self-specify how much they pay); fixed (costs are fixed, per the cost table); reserved (prepaid transaction, currently not supported) | { type = 'fixed' } |
+|allow_reservations | Does the network allow pre-payment / reservations for future execution? Currently not supported.| false |
+|gas_hold_balance_handling | Defines how gas holds affect available balance calculations. Valid options are: accrued (sum of full value of all non-expired holds) and amortized (sum of each hold is amortized over the time remaining until expiry). | { type = 'accrued' } |
+|gas_hold_interval | Defines how long gas holds last. | '24 hours'|
+|administrators | List of public keys of administrator accounts. Setting this option makes only on private chains which require administrator accounts for regulatory reasons. | [] |
+
+See the [Fee Elimination](../../concepts/economics/fee-elimination.md) page for more details regarding `refund_handling`, `fee_handling`, `validator_credit_cap`, `pricing_handling`, `gas_hold_balance_handling`, and `gas_hold_interval`.
 
 ## highway
 
@@ -62,8 +78,7 @@ These settings configure the Highway Consensus protocol.
 
 |Attribute         |Description                                    | Mainnet Setting |
 |----------------- |-----------------------------------------------|-----------------|
-|maximum_round_length | Highway dynamically chooses its round length between `minimum_block_time` and `maximum_round_length`. | '132seconds'|
-|reduced_reward_multiplier | The factor by which rewards for a round are multiplied if the greatest summit has ≤50% quorum, i.e., no finality. Expressed as a fraction (1/5 by default on Mainnet). | [1, 5]|
+|maximum_round_length | Highway dynamically chooses its round length between `minimum_block_time` and `maximum_round_length`. | '66 seconds'|
 
 ## transactions
 
@@ -71,20 +86,32 @@ These settings manage transactions and their lifecycle.
 
 |Attribute         |Description                                    | Mainnet Setting |
 |----------------- |-----------------------------------------------|-----------------|
-|max_payment_cost | The maximum number of motes allowed to be spent during payment. 0 means unlimited. | '0'|
-|max_ttl | The duration after the transaction timestamp during which the transaction can be included in a block. | '18hours'|
-|max_dependencies | The maximum number of other transactions a transaction can depend on (requiring them to have been executed before it can execute). | 10|
-|max_block_size | Maximum block size in bytes, including transactions contained by the block. 0 means unlimited. | 10_485_760|
-|max_transaction_size | Maximum transaction size in bytes. Size is of the transaction when serialized via ToBytes. | 1_048_576|
-|block_max_mint_count | Maximum number of mint transactions (i.e. transfers) allowed in a block.| 500|
-|block_max_auction_count | Maximum number of auction transactions allowed in a block. | 100|
-|block_max_install_upgrade_count | Maximum number of installer/upgrader transactions allowed in a block.| 2|
-|block_max_standard_count | Maximum number of other transactions (non-transfer, non-staking, non-installer/upgrader) allowed in a block.| 50|
+|max_ttl | The duration after the transaction timestamp during which the transaction can be included in a block. | '2 hours'|
 |block_max_approval_count | The maximum number of approvals permitted in a single block. | 2600|
-|block_gas_limit | The upper limit of the total gas of all transactions in a block. | 4_000_000_000_000|
+|max_block_size | Maximum block size in bytes, including transactions contained by the block. 0 means unlimited. | 5_242_880|
+|block_gas_limit | The upper limit of the total gas of all transactions in a block. | 3_300_000_000_000|
+|native_transfer_minimum_motes | The minimum amount in motes for a valid native transfer. | 2_500_000_000|
+|max_timestamp_leeway | The maximum value to which `transaction_acceptor.timestamp_leeway` can be set in the config.toml file. | '5 seconds' |
+
+### transactions.v1
+
+These settings manage the transaction lanes including both native and Wasm based interactions. See [Lanes and gas costs](../../concepts/economics/runtime.md#lanes-and-gas-costs-lanes) for details.
+
+|Attribute         | Mainnet Setting |
+|----------------- |-----------------|
+|native_mint_lane | [0, 1024, 1024, 65_000_000_000, 650] |
+|native_auction_lane | [1, 2048, 2048, 362_500_000_000, 145] |
+|wasm_lanes | [[2, 1_048_576, 2048, 1_000_000_000_000, 1], [3, 344_064, 1024, 500_000_000_000, 3], [4, 172_032, 1024, 50_000_000_000, 7], [5, 12_288, 512, 1_500_000_000, 15]] |
+
+
+### transactions.deploy
+
+|Attribute         |Description                                    | Mainnet Setting |
+|----------------- |-----------------------------------------------|-----------------|
+|max_payment_cost | The maximum number of motes allowed to be spent during payment. 0 means unlimited. | '0'|
+|max_dependencies | The maximum number of other transactions a transaction can depend on (requiring them to have been executed before it can execute). | 10|
 |payment_args_max_length | The limit of length of serialized payment code arguments. | 1024|
 |session_args_max_length | The limit of length of serialized session code arguments. | 1024|
-|native_transfer_minimum_motes | The minimum amount in motes for a valid native transfer. | 2_500_000_000|
 
 ## wasm
 
@@ -101,7 +128,7 @@ These settings manage Wasm storage costs.
 
 |Attribute         |Description                                    | Mainnet Setting |
 |----------------- |-----------------------------------------------|-----------------|
-|gas_per_byte | Gas charged per byte stored in global state. | 630_000|
+|gas_per_byte | Gas charged per byte stored in global state. | 1_117_587|
 
 ### wasm.opcode_costs
 
@@ -170,62 +197,61 @@ The following chainspec settings manage the cost of contract-level messages.
 
 The following settings specify costs for low-level bindings for host-side ("external") functions. More documentation and host function declarations are located in [smart_contracts/contract/src/ext_ffi.rs](https://github.com/casper-network/casper-node/blob/release-1.5.2/smart_contracts/contract/src/ext_ffi.rs).
 
-```
-- add = { cost = 5_800, arguments = [0, 0, 0, 0] }
-- add_associated_key = { cost = 9_000, arguments = [0, 0, 0] }
-- add_contract_version = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }
-- blake2b = { cost = 200, arguments = [0, 0, 0, 0] }
-- call_contract = { cost = 4_500, arguments = [0, 0, 0, 0, 0, 420, 0] }
-- call_versioned_contract = { cost = 4_500, arguments = [0, 0, 0, 0, 0, 0, 0, 420, 0] }
-- cost_increase_per_message = 50
-- create_contract_package_at_hash = { cost = 200, arguments = [0, 0] }
-- create_contract_user_group = { cost = 200, arguments = [0, 0, 0, 0, 0, 0, 0, 0] }
-- create_purse = { cost = 2_500_000_000, arguments = [0, 0] }
-- disable_contract_version = { cost = 200, arguments = [0, 0, 0, 0] }
-- emit_message = { cost = 200, arguments = [0, 0, 0, 0] }
-- get_balance = { cost = 3_800, arguments = [0, 0, 0] }
-- get_blocktime = { cost = 330, arguments = [0] }
-- get_caller = { cost = 380, arguments = [0] }
-- get_key = { cost = 2_000, arguments = [0, 440, 0, 0, 0] }
-- get_main_purse = { cost = 1_300, arguments = [0] }
-- get_named_arg = { cost = 200, arguments = [0, 0, 0, 0] }
-- get_named_arg_size = { cost = 200, arguments = [0, 0, 0] }
-- get_phase = { cost = 710, arguments = [0] }
-- get_system_contract = { cost = 1_100, arguments = [0, 0, 0] }
-- has_key = { cost = 1_500, arguments = [0, 840] }
-- is_valid_uref = { cost = 760, arguments = [0, 0] }
-- load_named_keys = { cost = 42_000, arguments = [0, 0] }
-- manage_message_topic = { cost = 200, arguments = [0, 0, 0, 0] }
-- new_uref = { cost = 17_000, arguments = [0, 0, 590] }
-- random_bytes = { cost = 200, arguments = [0, 0] }
-- print = { cost = 20_000, arguments = [0, 4_600] }
-- provision_contract_user_group_uref = { cost = 200, arguments = [0, 0, 0, 0, 0] }
-- put_key = { cost = 38_000, arguments = [0, 1_100, 0, 0] }
-- read_host_buffer = { cost = 3_500, arguments = [0, 310, 0] }
-- read_value = { cost = 6_000, arguments = [0, 0, 0] }
-- read_value_local = { cost = 5_500, arguments = [0, 590, 0] }
-- remove_associated_key = { cost = 4_200, arguments = [0, 0] }
-- remove_contract_user_group = { cost = 200, arguments = [0, 0, 0, 0] }
-- remove_contract_user_group_urefs = { cost = 200, arguments = [0, 0, 0, 0, 0, 0] }
-- remove_key = { cost = 61_000, arguments = [0, 3_200] }
-- ret = { cost = 23_000, arguments = [0, 420_000] }
-- revert = { cost = 500, arguments = [0] }
-- set_action_threshold = { cost = 74_000, arguments = [0, 0] }
-- transfer_from_purse_to_account = { cost = 2_500_000_000, arguments = [0, 0, 0, 0, 0, 0, 0, 0, 0] }
-- transfer_from_purse_to_purse = { cost = 82_000, arguments = [0, 0, 0, 0, 0, 0, 0, 0] }
-- transfer_to_account = { cost = 2_500_000_000, arguments = [0, 0, 0, 0, 0, 0, 0] }
-- update_associated_key = { cost = 4_200, arguments = [0, 0, 0] }
-- write = { cost = 14_000, arguments = [0, 0, 0, 980] }
-- write_local = { cost = 9_500, arguments = [0, 1_800, 0, 520] }
-```
+
+|Host-Side Function| Cost | Arguments |
+| ---------------- | ---- | --------- |
+| add | 5_800 | [0, 0, 0, 0] |
+| add_associated_key | 1_200_000 | [0, 0, 0] |
+| add_contract_version | 200 | [0, 0, 0, 0, 120_000, 0, 0, 0, 30_000, 0, 0] |
+| blake2b | 1_200_000 | [0, 120_000, 0, 0] |
+| call_contract | 300_000_000 | [0, 0, 0, 120_000, 0, 120_000, 0] |
+| call_versioned_contract | 300_000_000 | [0, 0, 0, 0, 120_000, 0, 120_000, 0] |
+| create_contract_package_at_hash | 200 | [0, 0] |
+| create_contract_user_group | 200 | [0, 0, 0, 0, 0, 0, 0, 0] |
+| create_purse | 2_500_000_000 | [0, 0] |
+| disable_contract_version | 200 | [0, 0, 0, 0] |
+| get_balance | 3_000_000 | [0, 0, 0] |
+| get_blocktime | 330 | [0] |
+| get_caller | 380 | [0] |
+| get_key | 2_000 | [0, 440, 0, 0, 0] |
+| get_main_purse | 1_300 | [0] |
+| get_named_arg | 200 | [0, 120_000, 0, 120_000] |
+| get_named_arg_size | 200 | [0, 0, 0] |
+| get_phase | 710 | [0] |
+| get_system_contract | 1_100 | [0, 0, 0] |
+| has_key | 1_500 | [0, 840] |
+| is_valid_uref | 760 | [0, 0] |
+| load_named_keys | 42_000 | [0, 0] |
+| new_uref | 17_000 | [0, 0, 590] |
+| random_bytes | 200 | [0, 0] |
+| print | 20_000 | [0, 4_600] |
+| provision_contract_user_group_uref | 200 | [0, 0, 0, 0, 0] |
+| put_key | 100_000_000 | [0, 120_000, 0, 120_000] |
+| read_host_buffer | 3_500 | [0, 310, 0] |
+| read_value | 60_000 | [0, 120_000, 0] |
+| read_value_local | 5_500 | [0, 590, 0] |
+| remove_associated_key | 4_200 | [0, 0] |
+| remove_contract_user_group | 200 | [0, 0, 0, 0] |
+| remove_contract_user_group_urefs | 200 | [0, 0, 0, 0, 0, 120_000] |
+| remove_key | 61_000 | [0, 3_200] |
+| ret | 23_000 | [0, 420_000] |
+| revert | 500 | [0] |
+| set_action_threshold | 74_000 | [0, 0] |
+| transfer_from_purse_to_account | 2_500_000_000 | [0, 0, 0, 0, 0, 0, 0, 0, 0] |
+| transfer_from_purse_to_purse | 82_000_000 | [0, 0, 0, 0, 0, 0, 0, 0] |
+| transfer_to_account | 2_500_000_000 | [0, 0, 0, 0, 0, 0, 0] |
+| update_associated_key | 4_200 | [0, 0, 0] |
+| write | 14_000 | [0, 0, 0, 980] |
+| dictionary_put | 9_500 | [0, 1_800, 0, 520] |
+| enable_contract_version | 200 | [0, 0, 0, 0] |
+| manage_message_topic | 200 | [0, 30_000, 0, 0] |
+| emit_message | 200 | [0, 30_000, 0, 120_000] |
+| cost_increase_per_message | 50 | |
+
 
 ## system_costs
 
 The following settings manage protocol operating costs.
-
-|Attribute         |Description                                    | Mainnet Setting |
-|----------------- |-----------------------------------------------|-----------------|
-|wasmless_transfer_cost | Default gas cost for a wasmless transfer. | 100_000_000|
 
 ### system_costs.auction_costs
 
@@ -247,6 +273,7 @@ These settings manage the costs of calling the `auction` system contract entrypo
 |read_era_id | Cost of calling the `read_era_id` entrypoint. | 10_000|
 |activate_bid | Cost of calling the `activate_bid` entrypoint. | 10_000|
 |redelegate | Cost of calling the `redelegate` entrypoint. | 2_500_000_000|
+|change_bid_public_key | Cost of calling the `change_bid_public_key` entrypoint. | 5_000_000_000 |
 
 ### system_costs.mint_costs
 
@@ -258,6 +285,7 @@ These settings manage the costs of calling the `mint` system contract entrypoint
 |reduce_total_supply | Cost of calling the `reduce_total_supply` entrypoint. | 10_000|
 |create | Cost of calling the `create` entrypoint. | 2_500_000_000|
 |balance | Cost of calling the `balance` entrypoint. | 10_000|
+|burn | Cost of calling the `burn` entrypoint. | 10_000|
 |transfer | Cost of calling the `transfer` entrypoint. | 10_000|
 |read_base_round_reward | Cost of calling the `read_base_round_reward` entrypoint. | 10_000|
 |mint_into_existing_purse | Cost of calling the `mint_into_existing_purse` entrypoint. | 2_500_000_000|

--- a/cspr-docs/docs/operators/setup-network/create-private.md
+++ b/cspr-docs/docs/operators/setup-network/create-private.md
@@ -77,6 +77,19 @@ refund_handling = { type = "refund", refund_ratio = [1, 1] }
 fee_handling = { type = "accumulate" }
 administrators = ["ADMIN_PUBLIC_KEY"]
 ```
+
+The Casper Mainnet has different refund and fee handling configurations explained in more detail [here](../../concepts/economics/fee-elimination.md).
+
+```toml
+[core]
+allow_unrestricted_transfers = true
+compute_rewards = true
+allow_auction_bids = true
+refund_handling = { type = 'no_refund' }
+fee_handling = { type = 'no_fee' }
+administrators = []
+```
+
 :::
 
 ### Refund handling configuration
@@ -89,15 +102,17 @@ A `refund_ratio` is specified as a proper fraction (the numerator must be lower 
 [core]
 refund_handling = { type = "refund", refund_ratio = [1, 1] }
 ```
+
+Another example: a refund variant with `refund_ratio` of [0, 100] means that 0% is given back to the user after deducting gas fees. In other words, if a user paid 2.5 CSPR and the gas fee is 1 CSPR, the user will not get the remaining 1.5 CSPR in return.
+
 After deducting the gas fee, the distribution of the remaining payment amount is handled based on the [fee_handling](./create-private.md#fee-handling-config) configuration.
 
-The default configuration for a public chain, including the Casper Mainet,  looks like this:
+Starting with the Condor release, a Casper private network can eliminate fees and, thus, not require refunds, similar to the Casper Mainnet:
 
 ```toml
-[core]
-refund_handling = { type = "refund", refund_ratio = [0, 100] }
+refund_handling = { type = 'no_refund' }
+fee_handling = { type = 'no_fee' }
 ```
-The refund variant with `refund_ratio` of [0, 100] means that 0% is given back to the user after deducting gas fees. In other words, if a user paid 2.5 CSPR and the gas fee is 1 CSPR, the user will not get the remaining 1.5 CSPR in return.
 
 ### Fee handling configuration
 This option defines how to distribute the fees after refunds are handled. While refund handling defines the amount we pay back after a transaction, fee handling defines the methods of fee distribution after a refund is performed.
@@ -110,7 +125,8 @@ Set up the configuration as below:
 fee_handling = { type = "pay_to_proposer" }
 ```
 
-The `fee_handling` configuration has three variations:
+The `fee_handling` configuration has four variations:
+- `no_fee`: Fees are eliminated. No refunds are necessary.
 - `pay_to_proposer`: The rest of the payment amount after deducing the gas fee from a refund is paid to the block's [proposer](../../concepts/glossary/P.md#proposer).
 - `burn`: The tokens paid are burned, and the total supply is reduced.
 - `accumulate`: The funds are transferred to a special accumulation purse. Here, the accumulation purse is owned by a handle payment system contract, and the amount is distributed among all the administrators defined at the end of a switch block. The fees are paid to the purse owned by the handle payment contract, and no tokens are transferred to the proposer when this configuration is enabled.

--- a/cspr-docs/docs/resources/build-on-casper.md
+++ b/cspr-docs/docs/resources/build-on-casper.md
@@ -15,7 +15,7 @@ This guide intends to briefly show you the current features and advantages of bu
   - [Contract Upgrades](#contract-upgrades)
   - [Development Tools](#development-tools)
   - [SDK Client Libraries](#sdk-client-libraries)
-  - [Low Gas Fees](#low-gas-fees)
+  - [No Gas Fees](#no-gas-fees)
 
 ## Thriving Ecosystem {#thriving-ecosystem}
 The Casper Ecosystem is growing every day through the addition of new dApps and tools. Here is a short list of tools you can use.
@@ -79,5 +79,5 @@ We also offer several tools to run AWS instances of Casper nodes.
 ## SDK Client Libraries {#sdk-client-libraries}
 In addition to the default [command-line Rust client](../developers/prerequisites.md#the-casper-command-line-client), the Casper community is building [other clients](/sdk) in JavaScript, Java, Golang, Python, C#, and other languages. 
 
-## Low Gas Fees {#low-gas-fees}
-Casper seeks to eliminate volatility and improve developer and enterprise experiences by establishing transparent, consistent, and low gas prices. This feature seeks to promote active and diverse network behaviour and we are researching innovative pricing models that will favor dApp developers as the ecosystem grows.
+## No Gas Fees {#no-gas-fees}
+Casper seeks to eliminate volatility and improve developer and enterprise experiences by [eliminating transaction fees](../concepts/economics/fee-elimination.md) on Mainnet. This feature seeks to promote active and diverse network behavior and we are researching innovative pricing models that will favor dApp developers as the ecosystem grows.

--- a/cspr-docs/docs/resources/tokens/cep18/full-tutorial.md
+++ b/cspr-docs/docs/resources/tokens/cep18/full-tutorial.md
@@ -213,9 +213,7 @@ casper-client query-global-state \
 
 Now you can install the contract to the network and check how it behaves.
 
-If you are sending the deploy on Mainnet, try several put deploys on the Testnet to understand the exact gas amount required for that deploy. Refer to the [note about gas price](/developers/cli/sending-transactions/#a-note-about-gas-price) to understand more about payment amounts and gas price adjustments.
-
-**The Casper platform currently does not refund any tokens as part of sending a deploy.** For example, if you spend 10 CSPR for the deployment and it only costs 1 CSPR, you will not receive the remaining 9 CSPR. Refer to the [Gas and the Casper Blockchain](/concepts/economics/gas-concepts/) documentation for further details.
+If you are sending the deploy on Mainnet, try several put deploys on the Testnet to understand the exact gas amount required for that deploy. Refer to the [Gas and the Casper Blockchain](/concepts/economics/gas-concepts/) documentation for further details.
 
 Use the following command template to deploy the contract:
 


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR ports the content from the old repository:
https://github.com/casper-network/docs/pull/1486/files

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@melpadden or @ACStoneCL 