### PR TITLE
Port PR 1489 and add link in the sidebar

### DIFF
--- a/cspr-docs/config/sidebar.config.js
+++ b/cspr-docs/config/sidebar.config.js
@@ -221,6 +221,7 @@ module.exports = {
                 "developers/cli/undelegate",
                 "developers/cli/sending-transactions",
                 "developers/cli/installing-contracts",
+                "developers/cli/verifying-contracts",
                 "developers/cli/querying-global-state",
                 "developers/cli/calling-contracts",
                 "developers/cli/opcode-costs",

--- a/cspr-docs/docs/developers/cli/index.md
+++ b/cspr-docs/docs/developers/cli/index.md
@@ -13,6 +13,7 @@ This section explains how to interact with a Casper network using the Casper com
 | [Undelegating Tokens with the Casper Client](./undelegate.md) | Undelegating tokens from a validator on a Casper network |
 | [Sending Deploys to a Network](./sending-transactions.md) | Sending Deploys to a Casper network using the Rust CLI Client |
 | [Installing Smart Contracts](./installing-contracts.md) | Steps to install a contract on a Casper network |
+| [Verifying contracts using the Casper Client](./verifying-contracts.md) | How to use Smart Contract Verification Service |
 | [Querying Global State](./querying-global-state.md) | How to query global state after contract installation |
 | [Calling Smart Contracts with the Rust Client](./calling-contracts.md) | Various ways to call a contract's entry-points |
 | [Execution Error Codes](./execution-error-codes.md) | Error codes for smart contract execution |

--- a/cspr-docs/docs/developers/cli/installing-contracts.md
+++ b/cspr-docs/docs/developers/cli/installing-contracts.md
@@ -11,7 +11,7 @@ This document details the process of installing [Casper smart contracts](../writ
 ## Prerequisites
 
 - You have a compiled contract (`.wasm` file) to send to a Casper network
-- You have installed the [Casper CLI client](../prerequisites.md#installing-the-casper-client-install-casper-clie) to interact with the network
+- You have installed the [Casper CLI client](../prerequisites.md#install-casper-client) to interact with the network
 - You have a [Casper Account](../prerequisites.md#setting-up-an-account) with a public and secret key pair to initiate the deploy
 - You have enough CSPR tokens in your account's main purse to pay for deploys. If you plan to use the Casper Testnet, learn about the [faucet](../../users/csprlive/testnet-faucet.md) to fund your testing account's main purse
 

--- a/cspr-docs/docs/developers/cli/verifying-contracts.md
+++ b/cspr-docs/docs/developers/cli/verifying-contracts.md
@@ -1,0 +1,35 @@
+---
+title: Verifying Contracts
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+# Verifying Smart Contracts
+
+This document describes actions needed for smart contract verification using the [Casper CLI client](../prerequisites.md#install-casper-client).
+
+## Prerequisites
+
+- You have built and installed a contract
+
+## Verifying contracts using the Casper Client {#verifying-the-contract}
+
+You can use the Casper client's `verify-contract` command to have your contract verified. This command archives your contract's source code and sends it to the verification service. This service performs all the same operations on the provided source that a node does when installing a smart contract on the blockchain. Based on the input transaction hash, the resulting binary is then compared byte-by-byte against the contract fetched from the Casper blockchain. If they match, then the verification is a success.
+
+```bash
+casper-client verify-contract --verification-url-basepath <HOST:PORT> <TRANSACTION-HASH> <PATH>
+```
+
+1. `verification-url-basepath` - The address of the verification service that will perform the operation; the current two options are https://staging.codeverifier.casper.network for Testnet and https://codeverifier.casper.network for Mainnet.
+2. `<TRANSACTION-HASH>` - Unique transaction hash, which is part of the cryptographic security of blockchain technology. This is the output of the put-txn command if the transaction was a success.
+3. `<PATH>` - Path to the smart contract's source code. If this argument is omitted, the current working directory will be used.
+
+The prerequisites for the source code are the same as when installing it on the blockchain:
+
+* The source code must be a Rust project as described in The Cargo Book.
+
+* There has to be either rust-toolchain or rust-toolchain.toml file and its contents must define a valid Rust toolchain, as described in The rustup book.
+
+* The installed contract (WebAssembly binary) must be stripped of debugging symbols before submitting it to the Casper node. This can be achieved by specifying strip = "symbols" in the Rust project configuration or using wasm-strip from the wabt package.
+
+If the verification is successful, then users will be able to see that information on various websites integrated with the service, e.g., on https://staging.casperecosystem.io/check-verification-status/ for Testnet transactions and https://casperecosystem.io/check-verification-status/ for Mainnet transactions. This will also allow them to browse through the source code of your smart contract, adding a new layer of transparency and trust.

--- a/cspr-docs/docs/developers/writing-onchain-code/getting-started.md
+++ b/cspr-docs/docs/developers/writing-onchain-code/getting-started.md
@@ -20,6 +20,16 @@ cargo casper my-project
 
 If you look inside the newly-created _my-project_ folder, you will find two crates: `contract` and `tests`. This is a complete basic smart contract that saves a value, passed as an argument, on the blockchain. The `tests` crate provides a runtime environment of the Casper virtual machine, and a basic smart contract test.
 
+### Reproducibility
+
+Currently, [cargo](https://github.com/rust-lang/cargo/issues/8140) does not provide cross-platform reproducibility for binary files, including WebAssembly. The ability to compile a smart contract to the same binary file is important, for example, when verifying that the smart contract binary stored on the blockchain is the same as the provided source code.
+
+To work around the issue, `cargo casper` crate provides `rustc` wrapper, which can be enabled using `--wrapper` option.
+
+```bash
+cargo casper my_project --wrapper
+```
+
 ### Using the nightly toolchain
 
 Navigate to the `my-project` folder and open the `rust-toolchain` file. You will notice that the file's contents specify a nightly version of Rust. Here is an example:
@@ -46,7 +56,7 @@ To support smart contract development with Rust, the following crates are publis
 - [casper-engine-test-support](https://crates.io/crates/casper-engine-test-support) - a virtual machine against which you can test your smart contracts.
 - [casper-types](https://crates.io/crates/casper-types) - a library with types we use across the Rust ecosystem.
 
-A crate is a compilation unit that can be compiled into a binary or a library. 
+A crate is a compilation unit that can be compiled into a binary or a library.
 
 :::note
 


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR ports the content from the old repository:
https://github.com/casper-network/docs/pull/1489/files
And adds a missing link in the sidebar, which was missed in the original PR.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@melpadden or @ACStoneCL 